### PR TITLE
Fix prefix not being added for conditional rules (@media, etc.)

### DIFF
--- a/index.es5.js
+++ b/index.es5.js
@@ -9,19 +9,22 @@
  * — https://twitter.com/subzey/status/829051085885153280
  */
 
+var selector = ':not(#\\20)';
+
 module.exports = function increaseIdSpecificity() {
   var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : { repeat: 3 },
       repeat = _ref.repeat;
 
-  var prefix = '';
-  for (var i = 0; i < repeat; i++) {
-    prefix += ':not(#\\20)';
-  }
-  return {
-    onProcessSheet: function onProcessSheet(sheet) {
-      sheet.rules.index.forEach(function (rule) {
-        rule.selectorText = prefix + rule.selectorText;
-      });
-    }
+  var prefix = Array(repeat + 1).join(selector);
+  var onProcessSheet = function onProcessSheet(sheet) {
+    sheet.rules.index.forEach(function (rule) {
+      if (rule.type === 'conditional') {
+        return onProcessSheet(rule);
+      }
+
+      rule.selectorText = prefix + rule.selectorText;
+    });
   };
+
+  return { onProcessSheet: onProcessSheet };
 };

--- a/index.js
+++ b/index.js
@@ -7,16 +7,19 @@
  * — https://twitter.com/subzey/status/829051085885153280
  */
 
+const selector = ':not(#\\20)';
+
 module.exports = function increaseIdSpecificity({ repeat }={ repeat: 3 }) {
-  let prefix = '';
-  for (let i = 0; i < repeat; i++) {
-    prefix += ':not(#\\20)';
-  }
-  return {
-    onProcessSheet(sheet) {
-      sheet.rules.index.forEach(rule => {
-        rule.selectorText = prefix + rule.selectorText;
-      })
-    }
-  }
+  const prefix = Array(repeat + 1).join(selector);
+  const onProcessSheet = (sheet) => {
+    sheet.rules.index.forEach(rule => {
+      if (rule.type === 'conditional') {
+        return onProcessSheet(rule);
+      }
+
+      rule.selectorText = prefix + rule.selectorText;
+    });
+  };
+
+  return { onProcessSheet };
 }


### PR DESCRIPTION
Basically in order to process conditional rules like `@media` we need to go inside them and traverse all rules as well, otherwise selectors outside of conditionals would have higher specificity.

Example:
```js
{
  // :not(#\20).title-0-0
  title: {
    fontSize: '16px'
  },
  '@media (max-width: 3000px)': {
    // .title-0-0
    // will always be less specific
    title: {
      fontSize: '20px'
    }
  }
}
```